### PR TITLE
Don't check for aws keys when there is no datasource #minor

### DIFF
--- a/lib/flare_up/cli.rb
+++ b/lib/flare_up/cli.rb
@@ -15,8 +15,10 @@ module FlareUp
         options.each { |k, v| boot_options[k.to_sym] = v }
 
         begin
-          CLI.env_validator(boot_options, :aws_access_key, 'AWS_ACCESS_KEY_ID')
-          CLI.env_validator(boot_options, :aws_secret_key, 'AWS_SECRET_ACCESS_KEY')
+          if data_source
+            CLI.env_validator(boot_options, :aws_access_key, 'AWS_ACCESS_KEY_ID')
+            CLI.env_validator(boot_options, :aws_secret_key, 'AWS_SECRET_ACCESS_KEY')
+          end
           CLI.env_validator(boot_options, :redshift_username, 'REDSHIFT_USERNAME')
           CLI.env_validator(boot_options, :redshift_password, 'REDSHIFT_PASSWORD')
         rescue ArgumentError => e


### PR DESCRIPTION
I only just noticed that if you run a command that does not require a datasource, like Truncate, without having `AWS_ACCESS_KEY_ID` and `AWS_ACCESS_KEY_SECRET` in your env the command wouldn't work but throw an error.

This PR fixes that minor by only checking for AWS credentials when there is a datasource
