### PR TITLE
Allow users to specify optional PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   [--aws-secret-key=AWS_SECRET_KEY]            # Required unless ENV['AWS_SECRET_ACCESS_KEY'] is set.
   [--redshift-username=REDSHIFT_USERNAME]      # Required unless ENV['REDSHIFT_USERNAME'] is set.
   [--redshift-password=REDSHIFT_PASSWORD]      # Required unless ENV['REDSHIFT_PASSWORD'] is set.
+  [--redshift-port=REDSHIFT_PORT]              # Optional (defaults to 5439)
   [--column-list=one two three]                # A space-separated list of columns, should your DATA_SOURCE require it
   [--copy-options=COPY_OPTIONS]                # Appended to the end of the COPY command; enclose "IN QUOTES"
   [--colorize-output], [--no-colorize-output]  # Should Flare-up colorize its output?
@@ -50,6 +51,7 @@ Options:
   [--column-list=COLUMN_LIST]                  # Required. A space-separated list of columns with their data-types, enclose "IN QUOTES"
   [--redshift-username=REDSHIFT_USERNAME]      # Required unless ENV['REDSHIFT_USERNAME'] is set.
   [--redshift-password=REDSHIFT_PASSWORD]      # Required unless ENV['REDSHIFT_PASSWORD'] is set.
+  [--redshift-port=REDSHIFT_PORT]              # Optional (defaults to 5439)
   [--colorize-output], [--no-colorize-output]  # Should Flare-up colorize its output?
                                                # Default: true
 ```
@@ -63,6 +65,7 @@ Usage:
 Options:
   [--redshift-username=REDSHIFT_USERNAME]      # Required unless ENV['REDSHIFT_USERNAME'] is set.
   [--redshift-password=REDSHIFT_PASSWORD]      # Required unless ENV['REDSHIFT_PASSWORD'] is set.
+  [--redshift-port=REDSHIFT_PORT]              # Optional (defaults to 5439)
   [--colorize-output], [--no-colorize-output]  # Should Flare-up colorize its output?
                                                # Default: true
 ```
@@ -76,6 +79,7 @@ Usage:
 Options:
   [--redshift-username=REDSHIFT_USERNAME]      # Required unless ENV['REDSHIFT_USERNAME'] is set.
   [--redshift-password=REDSHIFT_PASSWORD]      # Required unless ENV['REDSHIFT_PASSWORD'] is set.
+  [--redshift-port=REDSHIFT_PORT]              # Optional (defaults to 5439)
   [--colorize-output], [--no-colorize-output]  # Should Flare-up colorize its output?
                                                # Default: true
 ```

--- a/lib/flare_up/boot.rb
+++ b/lib/flare_up/boot.rb
@@ -32,11 +32,13 @@ module FlareUp
     end
 
     def self.create_connection
+      puts
       FlareUp::Connection.new(
         OptionStore.get(:redshift_endpoint),
         OptionStore.get(:database),
         OptionStore.get(:redshift_username),
-        OptionStore.get(:redshift_password)
+        OptionStore.get(:redshift_password),
+        OptionStore.get(:redshift_port)
       )
     end
     private_class_method :create_connection

--- a/lib/flare_up/cli.rb
+++ b/lib/flare_up/cli.rb
@@ -19,6 +19,7 @@ module FlareUp
           CLI.env_validator(boot_options, :aws_secret_key, 'AWS_SECRET_ACCESS_KEY')
           CLI.env_validator(boot_options, :redshift_username, 'REDSHIFT_USERNAME')
           CLI.env_validator(boot_options, :redshift_password, 'REDSHIFT_PASSWORD')
+          CLI.env_validator(boot_options, :redshift_port, 'REDSHIFT_PORT', 5439)
         rescue ArgumentError => e
           Emitter.error(e.message)
           CLI.bailout(1)
@@ -37,6 +38,7 @@ module FlareUp
     all_shared_options = [
       [:redshift_username, { :type => :string, :desc => "Required unless ENV['REDSHIFT_USERNAME'] is set." }],
       [:redshift_password, { :type => :string, :desc => "Required unless ENV['REDSHIFT_PASSWORD'] is set." }],
+      [:redshift_port, { :type => :numeric, :desc => "Optional (defaults to 5439)" }],
       [:colorize_output, { :type => :boolean, :desc => 'Should Flare-up colorize its output?', :default => true }]
     ]
     copy_options = [
@@ -108,8 +110,8 @@ in DATABASE_NAME at REDSHIFT_ENDPOINT.
       "FlareUp::Command::#{name}".split("::").reduce(Object) { |a, e| a.const_get e }
     end
 
-    def self.env_validator(options, option_name, env_variable_name)
-      options[option_name] ||= ENVWrap.get(env_variable_name)
+    def self.env_validator(options, option_name, env_variable_name, default_value=nil)
+      options[option_name] ||= (ENVWrap.get(env_variable_name) || default_value)
       return if options[option_name]
       raise ArgumentError, "One of either the --#{option_name} option or the ENV['#{env_variable_name}'] must be set"
     end

--- a/lib/flare_up/connection.rb
+++ b/lib/flare_up/connection.rb
@@ -22,13 +22,13 @@ module FlareUp
     attr_accessor :password
     attr_accessor :connect_timeout
 
-    def initialize(host, dbname, user, password)
+    def initialize(host, dbname, user, password, port)
       @host = host
       @dbname = dbname
       @user = user
       @password = password
 
-      @port = 5439
+      @port = port
       @connect_timeout = 5
     end
 
@@ -54,7 +54,7 @@ module FlareUp
           when /nodename nor servname provided, or not known/
             raise HostUnknownOrInaccessibleError, "Host unknown or unreachable: #{@host}"
           when /timeout expired/
-            raise TimeoutError, 'Timeout connecting to the database (have you checked your Redshift security groups?)'
+            raise TimeoutError, "Timeout connecting to the database (have you checked your Redshift security groups?), #{@port}"
           when /database ".+" does not exist/
             raise NoDatabaseError, "Database #{@dbname} does not exist"
           when /password authentication failed for user/

--- a/resources/load_hearthstone_cards.rb
+++ b/resources/load_hearthstone_cards.rb
@@ -5,7 +5,7 @@ db_name = 'dev'
 table_name = 'hearthstone_cards'
 data_source = 's3://slif-redshift/hearthstone_cards_short_list.csv'
 
-conn = FlareUp::Connection.new(host_name, db_name, ENV['REDSHIFT_USERNAME'], ENV['REDSHIFT_PASSWORD'])
+conn = FlareUp::Connection.new(host_name, db_name, ENV['REDSHIFT_USERNAME'], ENV['REDSHIFT_PASSWORD'], ENV['REDSHIFT_PORT'])
 
 copy = FlareUp::Command::Copy.new(table_name, data_source, ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
 copy.columns = %w(name cost attack health description)

--- a/spec/lib/flare_up/boot_spec.rb
+++ b/spec/lib/flare_up/boot_spec.rb
@@ -100,7 +100,8 @@ describe FlareUp::Boot do
           :redshift_endpoint => 'TEST_REDSHIFT_ENDPOINT',
           :database => 'TEST_DATABASE',
           :redshift_username => 'TEST_REDSHIFT_USERNAME',
-          :redshift_password => 'TEST_REDSHIFT_PASSWORD'
+          :redshift_password => 'TEST_REDSHIFT_PASSWORD',
+          :redshift_port => 5439
         }
       )
     end
@@ -111,6 +112,7 @@ describe FlareUp::Boot do
       expect(connection.dbname).to eq('TEST_DATABASE')
       expect(connection.user).to eq('TEST_REDSHIFT_USERNAME')
       expect(connection.password).to eq('TEST_REDSHIFT_PASSWORD')
+      expect(connection.port).to eq(5439)
     end
   end
 

--- a/spec/lib/flare_up/connection_spec.rb
+++ b/spec/lib/flare_up/connection_spec.rb
@@ -1,7 +1,7 @@
 describe FlareUp::Connection do
 
   subject do
-    FlareUp::Connection.new('TEST_HOST', 'TEST_DB_NAME', 'TEST_USER', 'TEST_PASSWORD')
+    FlareUp::Connection.new('TEST_HOST', 'TEST_DB_NAME', 'TEST_USER', 'TEST_PASSWORD', 5439)
   end
 
   let(:mock_pg_connection) { instance_double('PGConn') }
@@ -15,7 +15,7 @@ describe FlareUp::Connection do
 
   describe 'Writers' do
     subject do
-      FlareUp::Connection.new('', '', '', '').tap do |c|
+      FlareUp::Connection.new('', '', '', '', '').tap do |c|
         c.host = 'TEST_HOST'
         c.port = 111
         c.dbname = 'TEST_DB_NAME'

--- a/spec/lib/flare_up/emitter_spec.rb
+++ b/spec/lib/flare_up/emitter_spec.rb
@@ -45,7 +45,8 @@ describe FlareUp::Emitter do
             :aws_access_key => 'access',
             :aws_secret_key => 'secret',
             :redshift_username => 'user',
-            :redshift_password => 'pass'
+            :redshift_password => 'pass',
+            :redshift_port => '1234'
           })
       end
       it 'should hide it' do


### PR DESCRIPTION
Addresses #20 

Rather than use the hardcoded port of 5439, users can now enter
a custom port via one of the following:
   * Command line switch: `--redshift-port 5439`
   * Environment variable: `ENV['REDSHIFT_PORT']`

If neither is provided the default value of 5439 will be used.