### PR TITLE
Add the ability to use temporary credentials e.g. token field

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Usage:
 Options:
   [--aws-access-key=AWS_ACCESS_KEY]            # Required unless ENV['AWS_ACCESS_KEY_ID'] is set.
   [--aws-secret-key=AWS_SECRET_KEY]            # Required unless ENV['AWS_SECRET_ACCESS_KEY'] is set.
+  [--aws-secret-key=AWS_TOKEN]                 # Required for temporary credentials unless ENV['AWS_TOKEN'] is set.
   [--redshift-username=REDSHIFT_USERNAME]      # Required unless ENV['REDSHIFT_USERNAME'] is set.
   [--redshift-password=REDSHIFT_PASSWORD]      # Required unless ENV['REDSHIFT_PASSWORD'] is set.
   [--redshift-port=REDSHIFT_PORT]              # Optional (defaults to 5439)

--- a/lib/flare_up/boot.rb
+++ b/lib/flare_up/boot.rb
@@ -48,7 +48,8 @@ module FlareUp
         OptionStore.get(:table),
         OptionStore.get(:data_source),
         OptionStore.get(:aws_access_key),
-        OptionStore.get(:aws_secret_key)
+        OptionStore.get(:aws_secret_key),
+        OptionStore.get(:aws_token)
       )
       cmd.columns = OptionStore.get(:column_list) if OptionStore.get(:column_list)
       cmd.options = OptionStore.get(:copy_options) if OptionStore.get(:copy_options)

--- a/lib/flare_up/cli.rb
+++ b/lib/flare_up/cli.rb
@@ -17,6 +17,7 @@ module FlareUp
         begin
           CLI.env_validator(boot_options, :aws_access_key, 'AWS_ACCESS_KEY_ID')
           CLI.env_validator(boot_options, :aws_secret_key, 'AWS_SECRET_ACCESS_KEY')
+          CLI.env_validator(boot_options, :aws_token, 'AWS_TOKEN', nil, true)
           CLI.env_validator(boot_options, :redshift_username, 'REDSHIFT_USERNAME')
           CLI.env_validator(boot_options, :redshift_password, 'REDSHIFT_PASSWORD')
           CLI.env_validator(boot_options, :redshift_port, 'REDSHIFT_PORT', 5439)
@@ -44,6 +45,7 @@ module FlareUp
     copy_options = [
       [:aws_access_key, { :type => :string, :desc => "Required unless ENV['AWS_ACCESS_KEY_ID'] is set." }],
       [:aws_secret_key, { :type => :string, :desc => "Required unless ENV['AWS_SECRET_ACCESS_KEY'] is set." }],
+      [:aws_token, { :type => :string, :desc => "Required for temporary credentials unless ENV['AWS_TOKEN'] is set." }],
       [:copy_options, { :type => :string, :desc => "Appended to the end of the command; enclose \"IN QUOTES\"" }]
     ]
 
@@ -110,9 +112,9 @@ in DATABASE_NAME at REDSHIFT_ENDPOINT.
       "FlareUp::Command::#{name}".split("::").reduce(Object) { |a, e| a.const_get e }
     end
 
-    def self.env_validator(options, option_name, env_variable_name, default_value=nil)
+    def self.env_validator(options, option_name, env_variable_name, default_value=nil, optional=false)
       options[option_name] ||= (ENVWrap.get(env_variable_name) || default_value)
-      return if options[option_name]
+      return if options[option_name] || optional
       raise ArgumentError, "One of either the --#{option_name} option or the ENV['#{env_variable_name}'] must be set"
     end
 

--- a/lib/flare_up/command/copy.rb
+++ b/lib/flare_up/command/copy.rb
@@ -5,13 +5,15 @@ module FlareUp
       attr_reader :data_source
       attr_reader :aws_access_key_id
       attr_reader :aws_secret_access_key
+      attr_reader :aws_token
       attr_accessor :options
       attr_reader :columns
 
-      def initialize(table_name, data_source, aws_access_key_id, aws_secret_access_key)
+      def initialize(table_name, data_source, aws_access_key_id, aws_secret_access_key, aws_token=nil)
         @data_source = data_source
         @aws_access_key_id = aws_access_key_id
         @aws_secret_access_key = aws_secret_access_key
+        @aws_token = aws_token
         @options = ''
         @columns = []
         super
@@ -35,7 +37,11 @@ module FlareUp
       end
 
       def get_credentials
-        "aws_access_key_id=#{@aws_access_key_id};aws_secret_access_key=#{@aws_secret_access_key}"
+        if @aws_token.nil? || @aws_token.strip.empty?
+          "aws_access_key_id=#{@aws_access_key_id};aws_secret_access_key=#{@aws_secret_access_key}"
+        else
+          "aws_access_key_id=#{@aws_access_key_id};aws_secret_access_key=#{@aws_secret_access_key};token=#{@aws_token}"
+        end
       end
     end
   end

--- a/spec/lib/flare_up/boot_spec.rb
+++ b/spec/lib/flare_up/boot_spec.rb
@@ -137,6 +137,16 @@ describe FlareUp::Boot do
       expect(command.aws_secret_access_key).to eq('TEST_SECRET_KEY')
     end
 
+    context 'when aws token is provided' do
+      before do
+        FlareUp::OptionStore.store_option(:aws_token, 'TEST_TOKEN')
+      end
+      it 'should create a proper copy command' do
+        command = FlareUp::Boot.send(:create_command, FlareUp::Command::Copy)
+        expect(command.aws_token).to eq('TEST_TOKEN')
+      end
+    end
+
     context 'when columns are specified' do
       before do
         FlareUp::OptionStore.store_option(:column_list, ['c1'])

--- a/spec/lib/flare_up/cli_spec.rb
+++ b/spec/lib/flare_up/cli_spec.rb
@@ -12,6 +12,7 @@ describe FlareUp::CLI do
       :redshift_port => 5439,
       :aws_access_key => 'TEST_AWS_ACCESS_KEY',
       :aws_secret_key => 'TEST_AWS_SECRET_KEY',
+      :aws_token => nil,
       :colorize_output => true
     }
   end
@@ -19,6 +20,7 @@ describe FlareUp::CLI do
   before do
     allow(FlareUp::ENVWrap).to receive(:get).with('AWS_ACCESS_KEY_ID').and_return('TEST_AWS_ACCESS_KEY')
     allow(FlareUp::ENVWrap).to receive(:get).with('AWS_SECRET_ACCESS_KEY').and_return('TEST_AWS_SECRET_KEY')
+    allow(FlareUp::ENVWrap).to receive(:get).with('AWS_TOKEN').and_return(nil)
     allow(FlareUp::ENVWrap).to receive(:get).with('REDSHIFT_USERNAME').and_return('TEST_REDSHIFT_USERNAME')
     allow(FlareUp::ENVWrap).to receive(:get).with('REDSHIFT_PASSWORD').and_return('TEST_REDSHIFT_PASSWORD')
     allow(FlareUp::ENVWrap).to receive(:get).with('REDSHIFT_PORT').and_return(nil)
@@ -199,6 +201,26 @@ describe FlareUp::CLI do
             end
             it 'should be an error' do
               FlareUp::CLI.start(required_arguments)
+            end
+          end
+        end
+      end
+
+      describe 'token' do
+        context 'when an AWS token is specified' do
+          it 'should boot with the proper options' do
+            FlareUp::CLI.start(required_arguments + %w(--aws_token CLI_KEY))
+            expect(FlareUp::OptionStore.get(:aws_token)).to eq('CLI_KEY')
+          end
+        end
+        before do
+          allow(FlareUp::ENVWrap).to receive(:get).with('AWS_TOKEN').and_return('TEST_AWS_TOKEN')
+        end
+        context 'when an AWS token is not specified' do
+          context 'when the token is available via ENV' do
+            it 'should boot with the token from the environment' do
+              FlareUp::CLI.start(required_arguments)
+              expect(FlareUp::OptionStore.get(:aws_token)).to eq('TEST_AWS_TOKEN')
             end
           end
         end

--- a/spec/lib/flare_up/command/copy_spec.rb
+++ b/spec/lib/flare_up/command/copy_spec.rb
@@ -1,7 +1,11 @@
 describe FlareUp::Command::Copy do
 
-  subject do
+  subject(:copy_without_token) do
     FlareUp::Command::Copy.new('TEST_TABLE_NAME', 'TEST_DATA_SOURCE', 'TEST_ACCESS_KEY', 'TEST_SECRET_KEY')
+  end
+
+  subject(:copy_with_token) do
+    FlareUp::Command::Copy.new('TEST_TABLE_NAME', 'TEST_DATA_SOURCE', 'TEST_ACCESS_KEY', 'TEST_SECRET_KEY', 'TEST_TOKEN')
   end
 
   its(:table_name) { should == 'TEST_TABLE_NAME' }
@@ -14,25 +18,31 @@ describe FlareUp::Command::Copy do
   describe '#get_command' do
     context 'when no optional fields are provided' do
       it 'should return a basic COPY command' do
-        expect(subject.get_command).to eq("COPY TEST_TABLE_NAME  FROM 'TEST_DATA_SOURCE' CREDENTIALS 'aws_access_key_id=TEST_ACCESS_KEY;aws_secret_access_key=TEST_SECRET_KEY' ")
+        expect(copy_without_token.get_command).to eq("COPY TEST_TABLE_NAME  FROM 'TEST_DATA_SOURCE' CREDENTIALS 'aws_access_key_id=TEST_ACCESS_KEY;aws_secret_access_key=TEST_SECRET_KEY' ")
+      end
+    end
+
+    context 'with aws_token when no optional fields are provided' do
+      it 'should return a basic COPY command with token added to credentials' do
+        expect(copy_with_token.get_command).to eq("COPY TEST_TABLE_NAME  FROM 'TEST_DATA_SOURCE' CREDENTIALS 'aws_access_key_id=TEST_ACCESS_KEY;aws_secret_access_key=TEST_SECRET_KEY;token=TEST_TOKEN' ")
       end
     end
 
     context 'when column names are provided' do
       before do
-        subject.columns = %w(column_name1 column_name2)
+        copy_without_token.columns = %w(column_name1 column_name2)
       end
       it 'should include the column names in the command' do
-        expect(subject.get_command).to start_with('COPY TEST_TABLE_NAME (column_name1, column_name2) FROM')
+        expect(copy_without_token.get_command).to start_with('COPY TEST_TABLE_NAME (column_name1, column_name2) FROM')
       end
     end
 
     context 'when options are provided' do
       before do
-        subject.options = 'OPTION1 OPTION2'
+        copy_without_token.options = 'OPTION1 OPTION2'
       end
       it 'should include the options in the command' do
-        expect(subject.get_command).to end_with(' OPTION1 OPTION2')
+        expect(copy_without_token.get_command).to end_with(' OPTION1 OPTION2')
       end
     end
   end
@@ -40,18 +50,18 @@ describe FlareUp::Command::Copy do
   describe '#columns=' do
     context 'when an array' do
       it 'should assign the property' do
-        subject.columns = %w(column_name1 column_name2)
-        expect(subject.columns).to eq(%w(column_name1 column_name2))
+        copy_without_token.columns = %w(column_name1 column_name2)
+        expect(copy_without_token.columns).to eq(%w(column_name1 column_name2))
       end
     end
 
     context 'when not an array' do
       it 'should not assign the property and be an error' do
-        subject.columns = %w(column_name1)
+        copy_without_token.columns = %w(column_name1)
         expect {
-          subject.columns = '_'
+          copy_without_token.columns = '_'
         }.to raise_error(ArgumentError)
-        expect(subject.columns).to eq(%w(column_name1))
+        expect(copy_without_token.columns).to eq(%w(column_name1))
       end
     end
   end
@@ -65,7 +75,7 @@ describe FlareUp::Command::Copy do
         expect(conn).to receive(:execute)
       end
       it 'should do something' do
-        expect(subject.execute(conn)).to eq([])
+        expect(copy_without_token.execute(conn)).to eq([])
       end
     end
 
@@ -85,35 +95,35 @@ describe FlareUp::Command::Copy do
             allow(FlareUp::STLLoadErrorFetcher).to receive(:fetch_errors).and_return('FOO')
           end
           it 'should respond with a list of errors' do
-            expect(subject.execute(conn)).to eq('FOO')
+            expect(copy_without_token.execute(conn)).to eq('FOO')
           end
         end
 
         context 'when there was an error with the S3 prefix' do
           let(:message) { "The specified S3 prefix 'test_filename.csv' does not exist" }
           it 'should be an error' do
-            expect { subject.execute(conn) }.to raise_error(FlareUp::DataSourceError)
+            expect { copy_without_token.execute(conn) }.to raise_error(FlareUp::DataSourceError)
           end
         end
 
         context 'when the bucket is not in the same zone as the Redshift instance' do
           let(:message) { 'The bucket you are attempting to access must be addressed using the specified endpoint' }
           it 'should be an error' do
-            expect { subject.execute(conn) }.to raise_error(FlareUp::OtherZoneBucketError)
+            expect { copy_without_token.execute(conn) }.to raise_error(FlareUp::OtherZoneBucketError)
           end
         end
 
         context 'when there was another kind of internal error' do
           let(:message) { '_' }
           it 'should respond with a list of errors' do
-            expect { subject.execute(conn) }.to raise_error(PG::InternalError, '_')
+            expect { copy_without_token.execute(conn) }.to raise_error(PG::InternalError, '_')
           end
         end
 
         context 'when there is a syntax error in the command' do
           let(:message) { 'ERROR:  syntax error at or near "lmlkmlk3" (PG::SyntaxError)' }
           it 'should be error' do
-            expect { subject.execute(conn) }.to raise_error(FlareUp::SyntaxError, 'Syntax error in the COPY command: [at or near "lmlkmlk3"].')
+            expect { copy_without_token.execute(conn) }.to raise_error(FlareUp::SyntaxError, 'Syntax error in the COPY command: [at or near "lmlkmlk3"].')
           end
         end
       end
@@ -122,7 +132,7 @@ describe FlareUp::Command::Copy do
         let(:exception) { PG::ConnectionBad }
         let(:message) { '_' }
         it 'should do something' do
-          expect { subject.execute(conn) }.to raise_error(PG::ConnectionBad, '_')
+          expect { copy_without_token.execute(conn) }.to raise_error(PG::ConnectionBad, '_')
         end
       end
     end


### PR DESCRIPTION
Added the ability to use [AWS temporary credentials](http://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-credentials.html#copy-credentials-temporary)